### PR TITLE
Declare d before condition

### DIFF
--- a/sice_lib.py
+++ b/sice_lib.py
@@ -404,6 +404,7 @@ def zbrent(f, x0, x1, max_iter=100, tolerance=1e-6):
  
     mflag = True
     steps_taken = 0
+    d = np.nan
  
     while steps_taken < max_iter and abs(x1 - x0) > tolerance:
         fx0 = f(x0)


### PR DESCRIPTION
Variable `d` was not assigned before the condition. Just set it to nan so the condition can be tested and `d` possibly reassigned.