### PR TITLE
Use S3.xml and not S3_fast.xml anymore by default

### DIFF
--- a/S3_wrapper.sh
+++ b/S3_wrapper.sh
@@ -32,7 +32,7 @@ area=Greenland
 slopey=false
 
 # Fast processing
-fast=true
+fast=false
 
 # Error reporting
 error=false


### PR DESCRIPTION
pySICEv2.0 will require all bands to be processed, use S3.xml and not S3_fast.xml by default!