### PR TITLE
Update `eodata/` paths

### DIFF
--- a/dhusget_wrapper.sh
+++ b/dhusget_wrapper.sh
@@ -291,8 +291,8 @@ else
 
 	for product in $(cut -d, -f1 products-list.csv); do
 		local_subfolder="UNKNOWN_INSTRUMENT"
-		[[ ${product:4:8} == "OL_1_EFR" ]] && local_subfolder="OLCI/OL_1_EFR"
-		[[ ${product:4:8} == "SL_1_RBT" ]] && local_subfolder="SLSTR/SL_1_RBT"
+		[[ ${product:4:8} == "OL_1_EFR" ]] && local_subfolder="OLCI/OL_1_EFR___"
+		[[ ${product:4:8} == "SL_1_RBT" ]] && local_subfolder="SLSTR/SL_1_RBT___"
 
 		local_fullpath=${local_files}/${local_subfolder}/${year}/${month}/${day}/${product}.SEN3
 		(


### PR DESCRIPTION
ESA's data folder (`/eodata/`) structure changed in February 2023. OLCI and SLSTR data is now stored in `/eodata/Sentinel-3/OLCI/OL_1_EFR___` and `/eodata/Sentinel-3/OLCI/SL_1_RBT___` (and no more in `/eodata/Sentinel-3/OLCI/OL_1_EFR` and `/eodata/Sentinel-3/OLCI/SL_1_RBT`).